### PR TITLE
Extend list of Perls in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ perl:
   - "5.18"
   - "5.20"
   - "5.22"
+  - "5.24"
+  - "5.26"
 install: cpanm --quiet --notests AnyEvent autodie Plack HTTP::Request::Common Test::Class Test::More parent
 script: prove -l


### PR DESCRIPTION
Perls 5.24 and 5.26 are now supported by Travis.  This change brings the Travis config up to date.