### PR TITLE
Add META.json to distribution

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,3 +40,4 @@ parent                = 0
 [MetaProvides::Package]
 
 [SurgicalPodWeaver]
+[MetaJSON]


### PR DESCRIPTION
This fixes the [CPANTS](https://cpants.cpanauthors.org/dist/Plack-Test-AnyEvent) `has_meta_json` issue.  The META.json file will eventually replace META.yml as the file containing a dist's metadata.