### PR TITLE
Purge trailing whitespace

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -80,7 +80,7 @@ the exception is propagated by C<$res-E<gt>recv>.  Here's an example:
         my ( $respond ) = @_;
 
         die 'still thrown by $cb';
-            
+
         if($streaming) {
             my $writer = $respond->([
                 200,

--- a/lib/Plack/Test/AnyEvent.pm
+++ b/lib/Plack/Test/AnyEvent.pm
@@ -223,7 +223,7 @@ the exception is propagated by C<$res-E<gt>recv>.  Here's an example:
         my ( $respond ) = @_;
 
         die 'still thrown by $cb';
-            
+
         if($streaming) {
             my $writer = $respond->([
                 200,


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged. If you have any questions or comments concerning the PR, please simply contact me!