### PR TITLE
Update copyright year to year of current release

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -171,7 +171,7 @@ Rob Hoelz <rob@hoelz.ro>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2015 by Rob Hoelz.
+This software is copyright (c) 2017 by Rob Hoelz.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Plack-Test-AnyEvent
 author  = Rob Hoelz <rob@hoelz.ro>
 license = Perl_5
 copyright_holder = Rob Hoelz
-copyright_year   = 2015
+copyright_year   = 2017
 
 [@Author::RHOELZ]
 :version = 0.06


### PR DESCRIPTION
The copyright year hadn't been updated as part of the last release and was still set at 2015.  This change bumps the copyright year to the year of the current release.