### PR TITLE
Add strict and warnings to prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,8 @@ Carp     = 0
 HTTP::Request   = 0
 HTTP::Message::PSGI = 0
 IO::Handle = 0
+strict     = 0
+warnings   = 0
 
 [Prereqs / TestRequires]
 HTTP::Request::Common = 0


### PR DESCRIPTION
This will help to keep CPANTS happier and should close the
prereq_matches_use core quality issue mentioned there.