### PR TITLE
Add initial Appveyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+shallow_clone: false
+
+install:
+  - if not exist "C:\Strawberry" choco install strawberryperl --version 5.24.1.1
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --notest Dist::Zilla
+  - dzil authordeps --missing | cpanm --notest || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+  - dzil listdeps --author --missing | cpanm --notest || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+
+build_script:
+  - dzil test --author --release


### PR DESCRIPTION
[Appveyor](https://ci.appveyor.com) is effectively the Travis-CI for Windows systems.  This patch adds an Appveyor config to the project so that it can be tested automatically under Windows.

I've chosen *not* to use a shallow git clone since (during testing) I was getting errors about the `.git` directory not being able to be found, and this seemed to fix the issue.  I've also set the StrawberryPerl version to be 5.24, since `HTTP::Message::PSGI` doesn't install when using 5.26.

Note that the script hangs in much the same way as reported in #3.  I've manged to be able to see the compile tests run, but the remaining tests aren't shown, and I'm guessing the output doesn't appear due to buffering, but I suspect that the test run is hanging in the same place as in #3.

Hope this helps in at least *some* way!