### PR TITLE
Travis-ci: added support for ppc64le & Removed perl 5.8, 5.10, 5.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: perl
 perl:
-  - "5.8"
-  - "5.10"
-  - "5.12"
   - "5.14"
   - "5.16"
   - "5.18"
@@ -10,5 +7,8 @@ perl:
   - "5.22"
   - "5.24"
   - "5.26"
+arch: 
+  - AMD64
+  - ppc64le
 install: cpanm --quiet --notest AnyEvent autodie Plack HTTP::Request::Common Test::Class Test::More parent
 script: prove -l

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+
+0.08 July 19 2017
      Fix GH #3 - streaming apps hang on Windows (thanks to Alexandr Ciornii for reporting, and Paul Cochrane for helping me work on Windows)
 
 0.07 July 03 2017

--- a/README.pod
+++ b/README.pod
@@ -8,7 +8,7 @@ Plack::Test::AnyEvent - Run Plack::Test on AnyEvent-based PSGI applications
 
 =head1 VERSION
 
-version 0.07
+version 0.08
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.